### PR TITLE
Fix IntegrationNotFound exception

### DIFF
--- a/ha_install.sh
+++ b/ha_install.sh
@@ -323,6 +323,13 @@ sed -i 's/"mobile_app",//' default_config/manifest.json
 sed -i 's/"updater",//' default_config/manifest.json
 
 cd ../..
+sed -i 's/^    "_/    "_disabled_/' homeassistant/generated/zeroconf.py
+sed -i 's/_disabled_esphomelib./_esphomelib./' homeassistant/generated/zeroconf.py
+sed -i 's/_disabled_ipp./_ipp./' homeassistant/generated/zeroconf.py
+sed -i 's/_disabled_ipps./_ipps./' homeassistant/generated/zeroconf.py
+sed -i 's/_disabled_printer./_printer./' homeassistant/generated/zeroconf.py
+sed -i 's/_disabled_miio./_miio./' homeassistant/generated/zeroconf.py
+
 sed -i 's/    "/    # "/' homeassistant/generated/config_flows.py
 sed -i 's/    # "mqtt"/    "mqtt"/' homeassistant/generated/config_flows.py
 sed -i 's/    # "zha"/    "zha"/' homeassistant/generated/config_flows.py


### PR DESCRIPTION
When homekit device appears in the network home assistant starts to output the following errors:

```
2021-08-10 13:31:41 ERROR (MainThread) [homeassistant.config_entries] Cannot find integration homekit_controller
2021-08-10 13:31:41 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/homeassistant-2021.6.3-py3.9.egg/homeassistant/config_entries.py", line 687, in async_create_flow
    integration = await loader.async_get_integration(self.hass, handler_key)
  File "/usr/lib/python3.9/site-packages/homeassistant-2021.6.3-py3.9.egg/homeassistant/loader.py", line 536, in async_get_integration
    integration = await _async_get_integration(hass, domain)
  File "/usr/lib/python3.9/site-packages/homeassistant-2021.6.3-py3.9.egg/homeassistant/loader.py", line 561, in _async_get_integration
    raise IntegrationNotFound(domain)
homeassistant.loader.IntegrationNotFound: Integration 'homekit_controller' not found.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/homeassistant-2021.6.3-py3.9.egg/homeassistant/data_entry_flow.py", line 153, in async_init
    flow, result = await task
  File "/usr/lib/python3.9/site-packages/homeassistant-2021.6.3-py3.9.egg/homeassistant/data_entry_flow.py", line 171, in _async_init
    flow = await self.async_create_flow(handler, context=context, data=data)
  File "/usr/lib/python3.9/site-packages/homeassistant-2021.6.3-py3.9.egg/homeassistant/config_entries.py", line 690, in async_create_flow
    raise data_entry_flow.UnknownHandler from err
homeassistant.data_entry_flow.UnknownHandler
```

### How to reproduce

1. Add `zeroconf:` integration (if not already added) to `configuration.yaml`
2. Execute the following command from any machine in the network to send homekit multicast mdns message

```
avahi-publish -s Test _hap._tcp 12345 '["sh=eotXCg==" "ci=31" "sf=1" "s#=1" "pv=1.1" "md=TEST" "id=08:5A:0E:DF:63:6A" "ff=8" "c#=1"]'
```

3. Observe the error in the home assistant log file