### PR TITLE
Add back several internal components

### DIFF
--- a/ha_install.sh
+++ b/ha_install.sh
@@ -221,6 +221,7 @@ mv \
   default_config \
   device_automation \
   device_tracker \
+  dhcp \
   fan \
   frontend \
   google_assistant \
@@ -252,6 +253,7 @@ mv \
   onboarding \
   persistent_notification \
   person \
+  python_script \
   recorder \
   scene \
   script \
@@ -264,13 +266,16 @@ mv \
   switch \
   system_health \
   system_log \
+  time_date \
   timer \
   tts \
   updater \
   vacuum \
+  wake_on_lan \
   weather \
   webhook \
   websocket_api \
+  workday \
   xiaomi_aqara \
   xiaomi_miio \
   zeroconf \


### PR DESCRIPTION
I added back several components that I treat as internal as those is not related to any third-party devices or services. I tested all of those and they don't bring any errors.

The size of components is minimal:

dhcp: 12k
python_script: 8k
time_date: 6k
wake_on_lan: 7k
workday: 7k