### PR TITLE
Include python3 uuid package to fix pip3 missing dependency error

### DIFF
--- a/ha_install.sh
+++ b/ha_install.sh
@@ -135,6 +135,7 @@ opkg install \
   python3-slugify \
   python3-sqlalchemy \
   python3-sqlite3 \
+  python3-uuid \
   python3-unittest \
   python3-urllib \
   python3-urllib3 \

--- a/ha_install.sh
+++ b/ha_install.sh
@@ -520,7 +520,13 @@ sed -i -e 's/import mqtt/\0\nfrom .util import */g' -e 's/mqtt\.util\.//' mqtt/t
 sed -i 's/, "ffmpeg"//' tts/manifest.json
 sed -i 's/ ffmpeg,//' tts/__init__.py
 
-sed -i -e 's/"ha-av[^"]*", //' -e 's/"numpy[^"]*"/"numpy"/' stream/manifest.json
+# drop numpy dep from stream
+sed -i -e 's/"ha-av[^"]*", //' -e 's/, "numpy[^"]*"//' stream/manifest.json
+
+# soft float, like mips32 don't have numpy. Cut it off
+if ( ! ls /usr/lib/python3.11/site-packages/ | grep -q numpy ); then
+  sed -i -e 's/import numpy as np/np = None/' -e 's/np\.ndarray/Any/g' -e 's/TRANSFORM_IMAGE_FUNCTION[orientation]//' stream/core.py
+fi
 #sed -i -e 's/import av/#/' -e 's/av.logging/#/' stream/__init__.py
 sed -i 's/import av/av = None/' stream/__init__.py
 sed -i 's/import av/av = None/' stream/worker.py


### PR DESCRIPTION
When running the script on an Banana Pi R3 with OpenWRT 23.05.2, the installation script exited with the following error:

`Traceback (most recent call last):   File "/usr/bin/pip3", line 8, in <module>   sys.exit(main())`
`...`
`ModuleNotFoundError: No module named 'uuid'`

This is fixed by including the python3-uuid package in the opkg install command section of the script.
